### PR TITLE
Fix download URL for Feet version

### DIFF
--- a/GeocacheHeight/Geocache_Height_feet.meta.js
+++ b/GeocacheHeight/Geocache_Height_feet.meta.js
@@ -14,5 +14,5 @@
 // @icon        https://geo.inge.org.uk/userscripts/height48.png
 // @icon64      https://geo.inge.org.uk/userscripts/height64.png
 // @updateURL   https://geo.inge.org.uk/userscripts/Geocache_Height_feet.meta.js
-// @downloadURL https://openuserjs.org/install/JRI/Geocache_Height_feet.user.js
+// @downloadURL https://openuserjs.org/install/JRI/Geocache_Height_(feet).user.js
 // ==/UserScript==

--- a/GeocacheHeight/Geocache_Height_feet.user.js
+++ b/GeocacheHeight/Geocache_Height_feet.user.js
@@ -14,7 +14,7 @@
 // @icon        https://geo.inge.org.uk/userscripts/height48.png
 // @icon64      https://geo.inge.org.uk/userscripts/height64.png
 // @updateURL   https://geo.inge.org.uk/userscripts/Geocache_Height_feet.meta.js
-// @downloadURL https://openuserjs.org/install/JRI/Geocache_Height_feet.user.js
+// @downloadURL https://openuserjs.org/install/JRI/Geocache_Height_(feet).user.js
 // ==/UserScript==
 
 //

--- a/GeocacheHeight/src/Geocache_Height_feet.meta.js
+++ b/GeocacheHeight/src/Geocache_Height_feet.meta.js
@@ -14,5 +14,5 @@
 // @icon        https://geo.inge.org.uk/userscripts/height48.png
 // @icon64      https://geo.inge.org.uk/userscripts/height64.png
 // @updateURL   https://geo.inge.org.uk/userscripts/Geocache_Height_feet.meta.js
-// @downloadURL https://openuserjs.org/install/JRI/Geocache_Height_feet.user.js
+// @downloadURL https://openuserjs.org/install/JRI/Geocache_Height_(feet).user.js
 // ==/UserScript==


### PR DESCRIPTION
OpenUserJS.org seems to have changed its URL, to include the brackets from the script title...